### PR TITLE
Add template for SemaphoreCI Slack notifcation

### DIFF
--- a/.semaphore/slack-notification-releases.yml
+++ b/.semaphore/slack-notification-releases.yml
@@ -1,0 +1,27 @@
+# Notifies the #ci-notifications channel whenever changes are merged with 
+# the develop, main, master or development branches in any of our active 
+# repositories.
+# 
+# https://docs.semaphoreci.com/essentials/slack-notifications/
+apiVersion: v1alpha
+kind: Notification
+metadata:
+  name: release-cycle-notifications
+spec:
+  rules:
+    - name: "On development & production branches"
+      filter:
+        projects:
+          - /.*/
+        branches:
+          - development
+          - develop
+          - master
+          - main
+        results:
+          - passed
+      notify:
+        slack:
+          endpoint: https://hooks.slack.com/services/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
+          channels:
+            - "#ci-notifications"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # .github
 Community health files for the EnvolveTech organisation
+
+## SemaphoreCI
+Templates for SemaphoreCI Slack notifications can be found in the `.semaphore` directory.
+
+See the [SemaphoreCI docs](https://docs.semaphoreci.com/essentials/slack-notifications/) for instructions on how to configure Slack notifications.


### PR DESCRIPTION
This PR provides the YAML file that defines a Slack notification rule in our SemaphoreCI organisation. 

This notification connects with the Semaphore Slack App that was created on 30 December 2022. 

You can view this notification in the SemaphoreCI CLI using `sem get notifications`. 